### PR TITLE
Update Vagrantfile.master_slave to comment out puppet.pp_path = "/tmp/vagrant-puppet"

### DIFF
--- a/Vagrantfile.master_slave
+++ b/Vagrantfile.master_slave
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
 		end
 		node1_config.vm.network :private_network, ip: "192.168.70.2"
 		node1_config.vm.provision :puppet do |node1_puppet|
-			node1_puppet.pp_path = "/tmp/vagrant-puppet"
+			# node1_puppet.pp_path = "/tmp/vagrant-puppet"
 			node1_puppet.manifests_path = "manifests"
 			node1_puppet.module_path = "modules"
 			node1_puppet.manifest_file = "master_slave.pp"
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
 			end
 		node2_config.vm.network :private_network, ip: "192.168.70.3"
 			node2_config.vm.provision :puppet do |node2_puppet|
-				node2_puppet.pp_path = "/tmp/vagrant-puppet"
+			#	node2_puppet.pp_path = "/tmp/vagrant-puppet"
 				node2_puppet.manifests_path = "manifests"
 				node2_puppet.module_path = "modules"
 				node2_puppet.manifest_file = "master_slave.pp"
@@ -45,7 +45,7 @@ Vagrant.configure("2") do |config|
   		end
 			node3_config.vm.network :private_network, ip: "192.168.70.4"
   		node3_config.vm.provision :puppet do |node3_puppet|
-  			node3_puppet.pp_path = "/tmp/vagrant-puppet"
+  		#	node3_puppet.pp_path = "/tmp/vagrant-puppet"
   			node3_puppet.manifests_path = "manifests"
   			node3_puppet.module_path = "modules"
   			node3_puppet.manifest_file = "master_slave.pp"


### PR DESCRIPTION
vagrant up
Bringing machine 'node1' up with 'virtualbox' provider...
Bringing machine 'node2' up with 'virtualbox' provider...
Bringing machine 'node3' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

puppet provisioner:
- The following settings shouldn't exist: pp_path

To Fix this comment out #puppet.pp_path = "/tmp/vagrant-puppet"
